### PR TITLE
Dropping legacy `app.verbose()` and `app.warn()`.

### DIFF
--- a/sphinx_docstring_typing/__init__.py
+++ b/sphinx_docstring_typing/__init__.py
@@ -16,6 +16,11 @@ import ast
 import re
 import typing
 
+import sphinx.util.logging
+
+
+_LOGGER = sphinx.util.logging.getLogger(__name__)
+
 # All available type hints from the typing module.
 _TYPES = set(typing.__all__) - set((
     'cast', 'get_type_hints', 'NewType', 'no_type_check',
@@ -144,12 +149,12 @@ def autodoc_process_docstring(
                 new_line)
 
         except Exception as e:
-            app.warn(
+            _LOGGER.warn(
                 'sphinx-docstring-typing: Un-parseable line in docstring: \n'
                 '\t> %s \n\nException: %s' % (line, e))
 
         if line != new_line:
-            app.verbose(
+            _LOGGER.verbose(
                 'sphinx-docstring-typing: docstring line for %s replaced: '
                 '\n\t> %s \n\t> %s' % (name, line, new_line))
             lines[n] = new_line

--- a/tests/test_sphinx_docstring_typing.py
+++ b/tests/test_sphinx_docstring_typing.py
@@ -18,7 +18,7 @@ import pytest
 import sphinx_docstring_typing
 
 
-@pytest.mark.parametrize('input,expected', [
+@pytest.mark.parametrize('input_,expected', [
     (['Any'],
      [':py:obj:`~typing.Any`']),
     (['Sequence[int]'],
@@ -39,14 +39,16 @@ import sphinx_docstring_typing
     (['*Optional[datetime]*'],
      [':py:obj:`~typing.Optional` [ :py:obj:`datetime` ] ']),
 ])
-def test_autodoc_process_docstring(input, expected):
+def test_autodoc_process_docstring(input_, expected):
     app = mock.Mock()
-    app.warn.side_effect = print
-    app.verbose.side_effect = print
+    logger = mock.Mock()
+    logger.warn.side_effect = print
+    logger.verbose.side_effect = print
 
-    lines = list(input)
+    lines = list(input_)
 
-    sphinx_docstring_typing.autodoc_process_docstring(
-        app, None, None, None, None, lines)
+    with mock.patch.object(sphinx_docstring_typing, '_LOGGER', new=logger):
+        sphinx_docstring_typing.autodoc_process_docstring(
+            app, None, None, None, None, lines)
 
     assert lines == expected


### PR DESCRIPTION
Fixes #7.